### PR TITLE
Begin to stick correctly if top is more than zero

### DIFF
--- a/fixedsticky.js
+++ b/fixedsticky.js
@@ -86,7 +86,7 @@
 				$el.data( keys.position, position );
 			}
 
-			if( position.top && initialOffset < scroll || 
+			if( position.top && initialOffset < (scroll+height) ||
 				position.bottom && initialOffset > scroll + viewportHeight - ( height || 0 ) ) {
 
 				if( !isAlreadyOn ) {


### PR DESCRIPTION
When top is set to more than zero, the element would still start to stick after the scroll has passed it original position + height.
