### PR TITLE
Added QUnit to Bower Deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   ],
   "dependencies": {
     "jquery": ">=1.9.1 <2.0.0",
-    "filament-fixed": ">=0.1.1"
+    "filament-fixed": ">=0.1.1",
+    "qunit": ">=1.12.0"
   }
 }


### PR DESCRIPTION
QUnit was missing from the dependencies listed in the Bower manifest forcing tests to fail before they started.
