### PR TITLE
Add Firefox instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 
 ## Explanation
 
-CSS position:sticky is really in its infancy in terms of browser support. In stock browsers, it is currently only available in iOS 6. In Chrome you can enable it by navigating to `chrome://flags` and enabling experimental “WebKit features” or “Web Platform features” (Canary).
+CSS position:sticky is really in its infancy in terms of browser support. In stock browsers, it is currently only available in iOS 6.
+
+In Chrome you can enable it by navigating to `chrome://flags` and enabling experimental “WebKit features” or “Web Platform features” (Canary).
+
+In Firefox you you can go to `about:config` and set `layout.css.sticky.enabled` to "true".
 
 ## Usage
 


### PR DESCRIPTION
Firefox 26 now has experimental support for position:sticky behind a flag.

See https://developer.mozilla.org/en-US/Firefox/Releases/26 for details.
