### PR TITLE
This plugin works fine with jQuery 2.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "jquery": ">=1.9.1 <2.0.0",
+    "jquery": ">=1.9.1",
     "filament-fixed": ">=0.1.1",
     "qunit": ">=1.12.0"
   }


### PR DESCRIPTION
The API's are identical, so it makes no sense to limit this polyfill to
jQuery 1.9.
