### PR TITLE
init and destroy methods need to always return $el

### DIFF
--- a/fixedsticky.js
+++ b/fixedsticky.js
@@ -130,7 +130,7 @@
 		destroy: function( el ) {
 			var $el = $( el );
 			if (S.bypass()) {
-				return;
+				return $el;
 			}
 
 			return $el.each(function() {
@@ -149,7 +149,7 @@
 			var $el = $( el );
 
 			if( S.bypass() ) {
-				return;
+				return $el;
 			}
 
 			return $el.each(function() {


### PR DESCRIPTION
The init and destroy methods need to always return $el, even if they do nothing because feature detection says sticky positioning is natively supported, otherwise code using them for chaining would break. 