### PR TITLE
Position should be static by default when native behavior is ignored.

### DIFF
--- a/fixedsticky.css
+++ b/fixedsticky.css
@@ -6,6 +6,9 @@
 	position: sticky;
 }
 /* When position: sticky is supported but native behavior is ignored */
+.fixedsticky-withoutfixedfixed .fixedsticky{
+	position: static;
+}
 .fixedsticky-withoutfixedfixed .fixedsticky-off,
 .fixed-supported .fixedsticky-off {
 	position: static;


### PR DESCRIPTION
By default, `position: static` should be applied when native behavior is ignored.  

Otherwise, there are various scenarios where the element will retain `position: sticky` regardless of configuration. For example, if the jquery plugin was never applied to an element or if it's effect has later been destroyed, the element will still have `position: sticky` from the fixedsticky class. 
