### PR TITLE
Placeholder dummy need to mimic original element better

### DIFF
--- a/fixedsticky.js
+++ b/fixedsticky.js
@@ -75,7 +75,20 @@
 			if( initialOffset === undefined ) {
 				initialOffset = $el.offset().top;
 				$el.data( S.keys.offset, initialOffset );
-				$el.after( $( '<div>' ).addClass( S.classes.clone ).height( height ) );
+				
+				var clone = $( '<div>' )
+					.addClass( S.classes.clone )
+					.height( height )
+					.width( $el.outerWidth() )
+					.css({
+						'margin': $el.css('margin'), 
+						'float': $el.css('float'), 
+						'clear': $el.css('clear'), 
+						'display': $el.css('display'), 
+						'border-box': $el.css('border-box')
+					});
+				
+				$el.after( clone );
 			}
 
 			if( !position ) {


### PR DESCRIPTION
The placing of a dummy element that's suppose to fill the space of the original after its been sticky'd was fairly naive in its assumptions with regards to the positioning of the original element. I don't believe I've covered everything that may affect the original element's layout, but it should cover most cases now, unlike before, where it would break layout if something as simple as `float` was declared on the original element.