### PR TITLE
Remove postinstall to fix installing with NPM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - 0.10
+before_script:
+  - npm install -g bower
+  - bower install

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
 	"description": "A position: sticky polyfill that works with filamentgroup/fixed-fixed for a safer position:fixed fallback.",
 	"main": "fixedsticky.js",
 	"scripts": {
-		"test": "./node_modules/.bin/grunt test",
-		"postinstall": "./node_modules/.bin/bower install"
+		"test": "./node_modules/.bin/grunt test"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
The `postinstall` step causes installation as an NPM dependency to fail, because Bower is a `devDependency` and therefore will not be available unless the user has it installed globally.

#### Steps to reproduce:
`npm install fixed-sticky`

![screen shot 2015-04-01 at 11 11 07 am](https://cloud.githubusercontent.com/assets/583202/6944050/d634dde4-d85f-11e4-9463-d8cc27e770e8.png)
