### PR TITLE
bind() and unbind() have been deprecated

### DIFF
--- a/fixedsticky.js
+++ b/fixedsticky.js
@@ -138,7 +138,7 @@
 			return $el.each(function() {
 				var $this = $( this );
 				var id = $this.data( S.keys.id );
-				$( win ).unbind( '.fixedsticky' + id );
+				$( win ).off( '.fixedsticky' + id );
 
 				$this
 					.removeData( [ S.keys.offset, S.keys.position, S.keys.id ] )
@@ -159,11 +159,11 @@
 				var id = uniqueIdCounter++;
 				$( this ).data( S.keys.id, id );
 
-				$( win ).bind( 'scroll.fixedsticky' + id, function() {
+				$( win ).on( 'scroll.fixedsticky' + id, function() {
 					S.update( _this );
 				}).trigger( 'scroll.fixedsticky' + id );
 
-				$( win ).bind( 'resize.fixedsticky' + id , function() {
+				$( win ).on( 'resize.fixedsticky' + id , function() {
 					if( $el.is( '.' + S.classes.active ) ) {
 						S.update( _this );
 					}


### PR DESCRIPTION
https://jquery.com/upgrade-guide/3.0/#deprecated-bind-and-delegate

Officially deprecated in jQuery 3.0, but use of these functions have been discouraged since 1.7
